### PR TITLE
Added deprecations for button types

### DIFF
--- a/docs/src/PageLayoutDemos/SignIn.fs
+++ b/docs/src/PageLayoutDemos/SignIn.fs
@@ -95,7 +95,7 @@ let signIn props =
 
                 button [ HTMLAttr.Type "submit"
                          MaterialProp.FullWidth true
-                         ButtonProp.Variant ButtonVariant.Raised
+                         ButtonProp.Variant ButtonVariant.Contained
                          MaterialProp.Color ComponentColor.Primary
                          Class !!classes?submit ]  [
                     str "Sign in"

--- a/src/Fable.Helpers.MaterialUI.Props.fs
+++ b/src/Fable.Helpers.MaterialUI.Props.fs
@@ -1,5 +1,6 @@
 [<AutoOpen>]
 module rec Fable.MaterialUI
+open System
 
 [<AutoOpen>]
 module Themes =
@@ -970,10 +971,12 @@ module Props =
 
     type [<StringEnum; RequireQualifiedAccess>] ButtonVariant =
         | Text
-        | Flat
+        | [<Obsolete("Material-UI@3.2.0: The `flat` Button variant will be removed in the next major release of Material-UI. `text` is equivalent and should be used instead.")>]
+            Flat
         | Outlined
         | Contained
-        | Raised
+        | [<Obsolete("Material-UI@3.2.0: The `raised` Button variant will be removed in the next major release of Material-UI. `contained` is equivalent and should be used instead.")>]
+            Raised
         | Fab
         | ExtendedFab
 


### PR DESCRIPTION
`Raised` and `Flat` button variants are deprecated since version [3.2.0](https://github.com/mui-org/material-ui/releases/tag/v3.2.0) of Material-UI
