### PR TITLE
Add new icon colors props

### DIFF
--- a/src/Fable.MaterialUI.Props.fs
+++ b/src/Fable.MaterialUI.Props.fs
@@ -1431,6 +1431,9 @@ module Props =
         | Primary
         | Secondary
         | Action
+        | Success
+        | Warning
+        | Info
         | Error
         | Disabled
 


### PR DESCRIPTION
The [Material UI Icon API](https://mui.com/api/icon/) states that the color attribute can be:

> | 'inherit'
> | 'action'
> | 'disabled'
> | 'primary'
> | 'secondary'
> | 'error'
> | 'info'
> | 'success'
> | 'warning'

The goal of this PR is to add the lacking options to the IconColorProp.